### PR TITLE
export get_root

### DIFF
--- a/src/lib/utils/context.js
+++ b/src/lib/utils/context.js
@@ -35,7 +35,7 @@ export function setup(self) {
 }
 
 /** @returns {import('../types/context').RootContext} */
-function get_root() {
+export function get_root() {
 	return getContext(ROOT);
 }
 


### PR DESCRIPTION
I am working on a library that exposes https://github.com/vanruesc/postprocessing as svelte components.  I need access to the root three object, and didn't see any other way to access it.