### PR TITLE
fix: update tutorial to avoid crash

### DIFF
--- a/src/routes/docs/_content/01-getting-started/index.svelte.md
+++ b/src/routes/docs/_content/01-getting-started/index.svelte.md
@@ -42,6 +42,21 @@ If you're using TypeScript:
 npm install -D @types/three
 ```
 
+To make the `three` library work with svelte-cubed, you might need to add the following to your `svelte.config.js`:
+
+```js
+const config = {
+	kit: {
+		vite: {
+			ssr: {
+				noExternal: ["three"]
+			}
+		}
+	}
+};
+```
+(Only add the part that is missing from your `svelte.config.js`. Do not overwrite the whole contents.)
+
 Now you're ready to start building 3D graphics (in your project's `src/routes/index.svelte`, for example).
 
 ## Your first scene


### PR DESCRIPTION
Following the getting started tutorial as is causes a crash on the very first programming step for me and others - for details see issue #16. This workaround seems to fix that. 
 
Solution suggested by @niklasgrewe in https://github.com/Rich-Harris/svelte-cubed/issues/16#issuecomment-982553521_

Fixes #16