### PR TITLE
Change class name to avoid conflicts with other usages of generic class name "container"

### DIFF
--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -226,7 +226,7 @@
 
 <svelte:window on:resize={resize} />
 
-<div class="container" bind:this={container}>
+<div class="svelte-cubed-container" bind:this={container}>
 	<canvas bind:this={root.canvas} />
 
 	{#if root.scene}
@@ -235,7 +235,7 @@
 </div>
 
 <style>
-	.container,
+	.svelte-cubed-container,
 	canvas {
 		position: absolute;
 		width: 100%;


### PR DESCRIPTION
As discussed in #43 the class name "container" not only conflicts with TailwindCSSs "container" class but also other frameworks and user space CSS relies on this class name.