### PR TITLE
Remove division by pixelRatio

### DIFF
--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -172,11 +172,11 @@
 
 	const resize = () => {
 		if (width === undefined) {
-			_width = container.clientWidth / pixelRatio;
+			_width = container.clientWidth;
 		}
 
 		if (height === undefined) {
-			_height = container.clientHeight / pixelRatio;
+			_height = container.clientHeight;
 		}
 	};
 


### PR DESCRIPTION
This commit remove division by `pixelRatio` when the user specifies no `width` and `height` for the `SC.Canvas` component. If the division is present the rendering becomes blurry if the `pixelRatio` is `2` on the users device.

<img width="1512" alt="Screenshot 2022-04-02 at 17 32 56" src="https://user-images.githubusercontent.com/32162112/161390303-ec1b05ba-63c8-4714-b610-295a445f8e38.png">
No `width` and `height` set
<img width="1512" alt="Screenshot 2022-04-02 at 17 33 01" src="https://user-images.githubusercontent.com/32162112/161390312-f7583a61-21b1-4683-9c6f-e20b1eb49c5d.png">
`width` and `height` set