### PR TITLE
Add `Material | Material[]` type to `Mesh`

### DIFF
--- a/src/lib/components/objects/Mesh.svelte
+++ b/src/lib/components/objects/Mesh.svelte
@@ -7,6 +7,7 @@
 	/** @type {THREE.BufferGeometry} */
 	export let geometry = defaults.geometry;
 
+	/** @type {THREE.Material | THREE.Material[]} */
 	export let material = defaults.material;
 	export let position = defaults.position;
 	export let rotation = defaults.rotation;

--- a/src/routes/docs/_content/02-reference/index.svelte.md
+++ b/src/routes/docs/_content/02-reference/index.svelte.md
@@ -108,7 +108,7 @@ renderOrder: number = 0;
 
 ```ts
 geometry: THREE.BufferGeometry;
-material: THREE.Material = new THREE.MeshNormalMaterial();
+material: THREE.Material | THREE.Material[] = new THREE.MeshNormalMaterial();
 ```
 
 ### <Primitive>


### PR DESCRIPTION
Submitting as a solution to Issue #34.

This adds `Material | Material[]` as the type for the `material` property to be able to input an array of materials and not get type errors.
Passing in an array of `Material` is allowed in Threejs so `svelte-cubed` should allow it as well.

Thanks to @Myrmod for the suggested solution.